### PR TITLE
商品投稿時と商品編集中画面で税抜表示 & 投稿後と編集後は税込み表示に変更

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,9 +1,9 @@
+
 class ProductsController < ApplicationController
-  # before_action :move_purchase, only: [:purchase]   ????
   before_action :move_edit_destroy, only: [:edit, :destroy]
   before_action :set_product, only: [:edit, :show,:destroy,:purchase,:update]
   before_action :authenticate_user!, except: [:show,:index]
-
+  
   def index
     
     @product_new = Product.where(buyer_id: nil).order("created_at DESC").limit(3)
@@ -20,7 +20,11 @@ class ProductsController < ApplicationController
   end
 
   def create
+    # new.html.hamlにて入力された商品の値段はparams.require(:product)[:price]でとれます。(ただし、string型)この値段を税込み価格に変更してもらうProductクラスのメソッドを呼び出します。
+    params.require(:product)[:price]=Product.taxingPrice(params.require(:product)[:price])
+    
     @product = Product.new(product_params)
+
     if @product.save
       redirect_to products_path, notice: '商品を出品成功しました。'
     else
@@ -32,7 +36,8 @@ class ProductsController < ApplicationController
   end
 
   def edit
-
+    # show.html.hamlにて表示している価格を、edit.html.hamlでは「消費税抜き」に表示するため、Productクラスのメソッドを呼び出します。
+    @product.price = Product.detaxingPrice(@product.price)
     grandchild_category = @product.category
     child_category = grandchild_category.parent
 
@@ -45,6 +50,9 @@ class ProductsController < ApplicationController
   end
 
   def update
+    # edit.html.hamlにて入力された商品の値段はparams.require(:product)[:price]でとれます。(ただし、string型)この値段を税込み価格に変更してもらうProductクラスのメソッドを呼び出します。
+    params.require(:product)[:price]=Product.taxingPrice(params.require(:product)[:price])
+    
     if @product.update(update_params)
       redirect_to root_path, notice: '更新にに成功しました。'
     else

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,5 +1,5 @@
 class Product < ApplicationRecord
-
+  require 'bigdecimal'
 
    has_many :images,dependent: :destroy
    accepts_nested_attributes_for :images, allow_destroy: true
@@ -24,5 +24,19 @@ class Product < ApplicationRecord
   belongs_to_active_hash :prefecture
   belongs_to_active_hash :statushash
   belongs_to_active_hash :shippinghash
+  
+  # 税の定数を設定(税率を変えたい場合はこちらで変更願います。)
+  Taxrate = 1.1
 
+  # 引数の値段を消費税込みに変換して返します。
+  # string型の引数である商品の値段と税率(to_sへの変換が必要)を、BigDecimalに変換して計算後、小数点以下を破棄に変更)
+  def self.taxingPrice(a_price)
+    a_price=(BigDecimal(a_price)*BigDecimal(Taxrate.to_s)).floor
+    return a_price
+  end
+  # 引数の値段を消費税抜きに変換して返します。
+  def self.detaxingPrice(a_price)
+    a_price=(BigDecimal(a_price)/BigDecimal(Taxrate.to_s)).floor
+    return a_price
+  end
 end


### PR DESCRIPTION
products#new.html.hamlからの商品投稿時に記入する金額
と
products#edit.html.hamlでの商品編集時に記入されている & これから編集する金額
は税抜で記入していただければ、税込み価格でproductsテーブルに登録されるようにしました。

一方、products#show.html.hamlでの商品詳細情報
や
products#index.html.hamlで表示される価格は直接税込み価格が表示されます。

-------
上記のためにproductモデルではクラスメソッド「taxingPrice」と「detaxingPrice」を定義し、使用しています。

このproductsモデルで定数(Taxrate)を定義しています。
税率を変更したい場合、これを変更してください。