### PR TITLE
Wip 検索機能lv1

### DIFF
--- a/app/assets/javascripts/incsearch.js
+++ b/app/assets/javascripts/incsearch.js
@@ -1,0 +1,82 @@
+function buildSearchHTML(data){
+  // ajax通信後のdataをhtmlにまぜて返します。
+  var returnHTML=``;
+  for (var i=0;i<data.products.length;i++){
+    returnHTML+=
+    `<a class="#" href="/products/${data.products[i].id}">
+      <div class="fifthContent__list searchList">
+        <div class="fifthContent__list--image">
+          <image src="${data.images[i].image.url}">
+        </div>
+        <div class="fifthContent__list--underBox">
+          <div class="itemName">
+            ${data.products[i].name}
+          </div>
+
+          <div class="itemInformations">
+            <div>
+            ${data.products[i].price}
+            円
+            </div>
+            <div>
+            <i class="fa fa-star likeIcon"></i>
+            ０
+            </div>
+            <div>
+            出品者 ${data.salerusers[i].nikname} さん
+            </div>
+          </div>
+          <div>
+          (税込み)
+          </div>
+        </div>
+      </div>
+    </a>`;
+  }
+  return returnHTML;
+  
+}
+$(function(){
+  $('#result_form').on('keyup', function(e){
+    // フォーム内で、キーが押されれば発火します。
+    e.preventDefault();
+    //ajax通信ではフォームの内容をまるごとわたします。(ある意味でhtml版と同じ感覚で)それでもparams(:content)で同様に入力値だけ引き出せます。
+    // どうしても入力値だけ渡したいならdocument.getElementById("content").valueです。
+    var formData = new FormData(this);
+    // デバッグ用表示部分
+    console.log("---jqueryによるid=contentのinput要素の中身(=value)の表示----$('#content').val()---");
+    console.log($("#content").val());
+    // 上はhttps://maku77.github.io/js/jquery/form.htmlを参考に、フォームの入力内容をjqueryで参照しています。
+    console.log("---javascriptによるid=contentのinput要素の中身(=value)の表示----document.getElementById('content').value---");
+    //ajax通信でのdata(フォーム)の渡し先をフォームのaction値と同じにしたのでhtml版と同じになります。
+    var url = $(this).attr('action');
+    //ajax通信開始
+    console.log("ajax通信開始します。dataがformdataならば、processDataとcontentTypeはfalseにしてください。");
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    }).done(function(data){
+      // ajax通信完了後ですが、条件分岐します。
+      // もし入力値が「なにもない」か「空白だけ」の場合と、検索結果がない場合と、検索できた場合に分けます。
+      if($("#content").val().length==0 || $("#content").val()==" " ||$("#content").val()=="　"){
+        var html='出品された商品名で検索いたします。入力をお願いいたします。'
+      }else if (data.products.length > 0){
+        // 検索できた場合はメソッドにてデータを加工してもらいます。
+        var html=buildSearchHTML(data);
+      }else{
+        // 検索結果がない
+        var html='出品された商品名で検索しておりますが、該当するものがございませんでした。'
+      }
+      // 各場合
+      $('.searchLists').html(html);
+      // インクリメンタルサーチだからボタンを再度押せるようにする必要はないのですが、この書き方で可能です。
+      $('.searchBox__submit').prop("disabled", false);
+    }).fail(function(){
+      alert("error");
+    });
+  })
+})

--- a/app/assets/javascripts/incsearch.js
+++ b/app/assets/javascripts/incsearch.js
@@ -43,15 +43,9 @@ $(function(){
     //ajax通信ではフォームの内容をまるごとわたします。(ある意味でhtml版と同じ感覚で)それでもparams(:content)で同様に入力値だけ引き出せます。
     // どうしても入力値だけ渡したいならdocument.getElementById("content").valueです。
     var formData = new FormData(this);
-    // デバッグ用表示部分
-    console.log("---jqueryによるid=contentのinput要素の中身(=value)の表示----$('#content').val()---");
-    console.log($("#content").val());
-    // 上はhttps://maku77.github.io/js/jquery/form.htmlを参考に、フォームの入力内容をjqueryで参照しています。
-    console.log("---javascriptによるid=contentのinput要素の中身(=value)の表示----document.getElementById('content').value---");
     //ajax通信でのdata(フォーム)の渡し先をフォームのaction値と同じにしたのでhtml版と同じになります。
     var url = $(this).attr('action');
     //ajax通信開始
-    console.log("ajax通信開始します。dataがformdataならば、processDataとcontentTypeはfalseにしてください。");
     $.ajax({
       url: url,
       type: "POST",

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,4 +18,5 @@
 @import "addresses";
 @import "modules/_products_purchase";
 @import "modules/card_new";
-@import "modules/card_show"
+@import "modules/card_show";
+@import "modules/search";

--- a/app/assets/stylesheets/modules/_search.scss
+++ b/app/assets/stylesheets/modules/_search.scss
@@ -1,0 +1,8 @@
+.searchMain{
+  & .searcContentLow{
+    height: 1200px;
+  }
+  & .searchLists{
+    flex-wrap: wrap;
+  }
+}

--- a/app/assets/stylesheets/modules/_search.scss
+++ b/app/assets/stylesheets/modules/_search.scss
@@ -1,8 +1,25 @@
 .searchMain{
   & .searcContentLow{
-    height: 1200px;
+    height: 940px;
   }
   & .searchLists{
     flex-wrap: wrap;
+    & .searchList{
+      margin-bottom: 30px;
+    }
+  }
+}
+.sarchPaginate{
+  background-color: $mainGray;
+  text-align: center;
+  padding-bottom: 50px;
+  font-size: 20px;
+  & .pagination{
+      & .current{
+        color: $mainBlue;
+    }
+    & a{
+      color: black;
+    }
   }
 }

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -10,7 +10,7 @@ class ProductsController < ApplicationController
     @product_random = Product.where(buyer_id: nil).order("RAND()").limit(3)
   end
   def search
-    @products = Product.where.not(buyer_id: nil).order("updated_at DESC")
+    @products = Product.where(buyer_id: nil).order("updated_at DESC")
     # @products = Product.all
   end
   def new

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -18,8 +18,6 @@ class ProductsController < ApplicationController
     
   end
   def result
-    # binding.pry
-    puts "--products#result--"
     # search.html.hamlのフォームに入力された値をもとにproductsのnameを曖昧検索します。
     @products = Product.includes(:images).where("name LIKE ?","%#{params[:content]}%").order("updated_at DESC").page(params[:page]).per(9)
     # ajax通信後のjson.jbuilderに対応する配列(画像のファイル名と出品者名)を設定します。

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -13,10 +13,32 @@ class ProductsController < ApplicationController
   def search
     # search.html.hamlには「売り切れではなく、商品の更新日時の降順」で表示します。
     @products = Product.where(buyer_id: nil).order("updated_at DESC").page(params[:page]).per(9)
+    # レスポンスを形式によってわけます
+    
+    
   end
   def result
+    # binding.pry
+    puts "--products#result--"
     # search.html.hamlのフォームに入力された値をもとにproductsのnameを曖昧検索します。
-    @products = Product.where("name LIKE ?","%#{params[:content]}%").order("updated_at DESC").page(params[:page]).per(9)
+    @products = Product.includes(:images).where("name LIKE ?","%#{params[:content]}%").order("updated_at DESC").page(params[:page]).per(9)
+    # ajax通信後のjson.jbuilderに対応する配列(画像のファイル名と出品者名)を設定します。
+    @images =[]
+    @salerusers =[]
+    # 検索された商品に対応するimageレコードと、出品者に当たるuserレコードを配列にpushします。
+    @products.each do |product|
+      image = Image.find_by(product_id: product.id)
+      @images <<image
+      user =User.find_by(id: product.saler_id)
+      @salerusers << user  
+    end
+    # formatごとにリダイレクト先を変えたりできますが、今回はあまり意味がないと考え設定していません。
+    respond_to do |format|
+      # 例えば format.html redirect_to result_pathとか。
+      format.html
+      format.json
+    end
+    # result.json.jbuilderではこの@products(ActiveRecord::Relation)と@images(Array)と@salerusers(Array)を使用し、doneのdataになるようにします。
   end
   def new
     @product = Product.new

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -9,7 +9,10 @@ class ProductsController < ApplicationController
     @product_new = Product.where(buyer_id: nil).order("created_at DESC").limit(3)
     @product_random = Product.where(buyer_id: nil).order("RAND()").limit(3)
   end
-
+  def search
+    @products = Product.all
+    # @products = Product.all.order("created_at DESC").page(params[:page]).per(5)
+  end
   def new
     @product = Product.new
     @product.images.new

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -20,6 +20,9 @@ class ProductsController < ApplicationController
   def result
     # search.html.hamlのフォームに入力された値をもとにproductsのnameを曖昧検索します。
     @products = Product.includes(:images).where("name LIKE ?","%#{params[:content]}%").order("updated_at DESC").page(params[:page]).per(9)
+    # @products = Product.includes(:images).where("name LIKE ?","%#{params[:content]}%").order("updated_at DESC")
+    # important - もしpagenate型のレコード取得をやめるなら、result.html.hamlのpagenate部分の消去が必要です。
+    
     # ajax通信後のjson.jbuilderに対応する配列(画像のファイル名と出品者名)を設定します。
     @images =[]
     @salerusers =[]

--- a/app/views/products/_header.haml
+++ b/app/views/products/_header.haml
@@ -13,7 +13,7 @@
           = link_to "#", class: "linkBlack" do
             カテゴリー
         %li.leftlists__right
-          = link_to "#", class: "linkBlack" do
+          = link_to search_path, class: "linkBlack" do
             商品一覧
       %ul.rightlists
         - if user_signed_in?

--- a/app/views/products/_header.haml
+++ b/app/views/products/_header.haml
@@ -4,7 +4,7 @@
       = link_to root_path, class: "logoBox" do
         %div
       .searchBox
-        = form_with model:@post,class: "searchBox__form", local: true do |f|
+        = form_with model:@post,class: "searchBox__form", local: true, url: {controller: 'products', action: 'result' } do |f|
           = f.text_field :content,class: "searchBox__input", placeholder:"キーワードから探す"
           = f.submit "", class: "searchBox__submit"
     .headerLists

--- a/app/views/products/result.html.haml
+++ b/app/views/products/result.html.haml
@@ -5,7 +5,7 @@
       = link_to root_path, class: "logoBox" do
         %div
       .searchBox
-        = form_with model:@post,class: "searchBox__form", local: true do |f|
+        = form_with model:@product,class: "searchBox__form", local: true, id: "result_form" do |f|
           = f.text_field :content,class: "searchBox__input", placeholder:"キーワードから探す"
           = f.submit "", class: "searchBox__submit"
     .headerLists
@@ -30,7 +30,7 @@
 .main.searchMain
   .fifthContentLow.searcContentLow
     .fifthContent__title
-      ぴっくあっぷかてごりーピックアップカテゴリー
+      検索結果
     .fifthContent__box.searchBox
       .fifthContent__box--title
         = link_to "#", class: "linkBlue" do
@@ -53,6 +53,10 @@
                   %div
                     %i.fa.fa-star.likeIcon
                     ０
+                  %div
+                    出品者
+                    = User.find(product.saler_id).nikname
+                    さん
                 %div
                   (税込)
         = paginate @products

--- a/app/views/products/result.html.haml
+++ b/app/views/products/result.html.haml
@@ -59,5 +59,5 @@
                     さん
                 %div
                   (税込)
-        = paginate @products
+         = paginate @products
 = render "products/footer"

--- a/app/views/products/result.html.haml
+++ b/app/views/products/result.html.haml
@@ -59,5 +59,5 @@
                     さん
                 %div
                   (税込)
-         = paginate @products
+        = paginate @products
 = render "products/footer"

--- a/app/views/products/result.json.jbuilder
+++ b/app/views/products/result.json.jbuilder
@@ -1,0 +1,3 @@
+json.products @products
+json.images @images
+json.salerusers @salerusers

--- a/app/views/products/search.html.haml
+++ b/app/views/products/search.html.haml
@@ -1,0 +1,4 @@
+= render 'layouts/notifications'
+.search_form
+.search_result
+= render "products/footer"

--- a/app/views/products/search.html.haml
+++ b/app/views/products/search.html.haml
@@ -27,15 +27,15 @@
             = link_to "ログイン", new_user_session_path, class: "linkBlack"
           %li.rightlists__right
             = link_to "新規登録", new_user_registration_path, class: "linkBlack"
-.main
-  .fifthContentLow
+.main.searchMain
+  .fifthContentLow.searcContentLow
     .fifthContent__title
       ピックアップカテゴリー
-    .fifthContent__box
+    .fifthContent__box.searchBox
       .fifthContent__box--title
         = link_to "#", class: "linkBlue" do
           新規投稿商品 
-      .fifthContent__lists
+      .fifthContent__lists.searchLists
         - @products.each do |product|
           = link_to product_path(product.id), class: "#" do
             .fifthContent__list

--- a/app/views/products/search.html.haml
+++ b/app/views/products/search.html.haml
@@ -38,7 +38,7 @@
       .fifthContent__lists.searchLists
         - @products.each do |product|
           = link_to product_path(product.id), class: "#" do
-            .fifthContent__list
+            .fifthContent__list.searchList
               .fifthContent__list--image
                 - product.images.first(1).each do |image|
                   = image_tag image.image.url
@@ -55,5 +55,6 @@
                     ０
                 %div
                   (税込)
-        = paginate @products
+%div.sarchPaginate
+  = paginate @products
 = render "products/footer"

--- a/app/views/products/search.html.haml
+++ b/app/views/products/search.html.haml
@@ -27,6 +27,7 @@
             = link_to "ログイン", new_user_session_path, class: "linkBlack"
           %li.rightlists__right
             = link_to "新規登録", new_user_registration_path, class: "linkBlack"
+.main
   .fifthContentLow
     .fifthContent__title
       ピックアップカテゴリー
@@ -36,7 +37,7 @@
           新規投稿商品 
       .fifthContent__lists
         - @products.each do |product|
-          = link_to product_path(new.id), class: "#" do
+          = link_to product_path(product.id), class: "#" do
             .fifthContent__list
               .fifthContent__list--image
                 - product.images.first(1).each do |image|

--- a/app/views/products/search.html.haml
+++ b/app/views/products/search.html.haml
@@ -1,4 +1,57 @@
 = render 'layouts/notifications'
-.search_form
-.search_result
+%header
+  .headerLow
+    .mainHeader
+      = link_to root_path, class: "logoBox" do
+        %div
+      .searchBox
+        = form_with model:@post,class: "searchBox__form", local: true do |f|
+          = f.text_field :content,class: "searchBox__input", placeholder:"キーワードから探す"
+          = f.submit "", class: "searchBox__submit"
+    .headerLists
+      %ul.leftlists
+        %li.leftlists__left
+          = link_to "#", class: "linkBlack" do
+            カテゴリー
+        %li.leftlists__right
+          = link_to "#", class: "linkBlack" do
+            商品一覧
+      %ul.rightlists
+        - if user_signed_in?
+          %li.rightlists__left
+            = link_to "マイページ", user_path(current_user), class: "linkBlack"
+          %li.rightlists__right
+            = link_to "ログアウト", destroy_user_session_path, method: :delete, class: "linkBlack"
+        - else
+          %li.rightlists__left
+            = link_to "ログイン", new_user_session_path, class: "linkBlack"
+          %li.rightlists__right
+            = link_to "新規登録", new_user_registration_path, class: "linkBlack"
+  .fifthContentLow
+    .fifthContent__title
+      ピックアップカテゴリー
+    .fifthContent__box
+      .fifthContent__box--title
+        = link_to "#", class: "linkBlue" do
+          新規投稿商品 
+      .fifthContent__lists
+        - @products.each do |product|
+          = link_to product_path(new.id), class: "#" do
+            .fifthContent__list
+              .fifthContent__list--image
+                - product.images.first(1).each do |image|
+                  = image_tag image.image.url
+              .fifthContent__list--underBox
+                %div.itemName
+                  = product.name
+                .itemInformations
+                  %div
+                    = product.price
+                    円
+                    
+                  %div
+                    %i.fa.fa-star.likeIcon
+                    ０
+                %div
+                  (税込)
 = render "products/footer"

--- a/app/views/products/search.html.haml
+++ b/app/views/products/search.html.haml
@@ -30,7 +30,7 @@
 .main.searchMain
   .fifthContentLow.searcContentLow
     .fifthContent__title
-      ピックアップカテゴリー
+      New Item
     .fifthContent__box.searchBox
       .fifthContent__box--title
         = link_to "#", class: "linkBlue" do

--- a/app/views/products/search.html.haml
+++ b/app/views/products/search.html.haml
@@ -49,7 +49,6 @@
                   %div
                     = product.price
                     円
-                    
                   %div
                     %i.fa.fa-star.likeIcon
                     ０

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,9 @@ Rails.application.routes.draw do
   resources :users, only: [:show,:index]
   resources :addresses, only: [:new, :create, :index]
   get 'search' ,to: 'products#search'
+  # get 'result' ,to: 'products#result'
   post 'result' ,to: 'products#result'
+ 
   # 上記の記述は商品検索ページ用のルートです。
   resources :products do
     member do


### PR DESCRIPTION
# what
インクリメンタルサーチを実装いたしました。

# how
topページ上部の「商品一覧」をおして/searchへ移動
→なにか入力して検索 or 入力しなくても検索ボタンをおして/resultへ移動
→/resultのページ内ではインクリメンタルサーチが可能です。

出品者も表示されるようにしています。

# important
productsコントローラのresultアクション内の
```
@products = Product.includes(:images).where("name LIKE ?","%#{params[:content]}%").order("updated_at DESC").page(params[:page]).per(9)
```
は、searchアクションと同様に「kaminariGem対応」なレコードの取得の仕方になっていますが、インクリメンタルサーチだと実質意味がないかもしれません。
その場合
```
@products = Product.includes(:images).where("name LIKE ?","%#{params[:content]}%").order("updated_at DESC")
```
に変えたなら、result.html.hamlのpagenate部分の消去が必要になります。

# why
このような実装内容でmergeして良いか、
またpagenate対応をやめたインクリメンタルサーチとした方がよいか
を伺います。